### PR TITLE
Fix aja in not working correctly in linux

### DIFF
--- a/AJA.noscfg
+++ b/AJA.noscfg
@@ -2,7 +2,7 @@
     "info": {
         "id": {
             "name": "nos.aja",
-            "version": "2.7.0"
+            "version": "2.7.1"
         },
         "display_name": "AJA",
         "description": "Video I/O plugin for AJA cards.",

--- a/Source/AJADevice.cpp
+++ b/Source/AJADevice.cpp
@@ -1017,18 +1017,20 @@ bool AJADevice::AcquireDevice()
     if (GetStreamingApplication(curAppFourCC, curPid))
     {
         if (curPid == nosPid)
-            return true;
-		auto curApp = FourCCToString(curAppFourCC);
-        if (curPid != 0)
-		    nosEngine.LogW("Device %s is already acquired by application %s (PID %d). Trying to reclaim it.", GetDisplayName().c_str(), curApp.c_str(), curPid);
+        {
+            auto curApp = FourCCToString(curAppFourCC);
+            if (curPid != 0)
+		        nosEngine.LogW("Device %s is already acquired by application %s (PID %d). Trying to reclaim it.", GetDisplayName().c_str(), curApp.c_str(), curPid);
+        }
     }
 
-    if (!AcquireStreamForApplication(NOS_FOURCC, nosPid))
+    if (!AcquireStreamForApplicationWithReference(NOS_FOURCC, nosPid))
     {
 		nosEngine.LogE("Failed to acquire device %s for Nodos.", GetDisplayName().c_str());
 		return false;
     }
-    nosEngine.LogD("Device %s acquired by Nodos.", GetDisplayName().c_str());
+    if(nosPid != curPid)
+        nosEngine.LogD("Device %s acquired by Nodos.", GetDisplayName().c_str());
     return true;
 }
 
@@ -1052,7 +1054,7 @@ void AJADevice::ReleaseDevice()
 		return;
     }
 
-    if (ReleaseStreamForApplication(NOS_FOURCC, nosPid))
+    if (ReleaseStreamForApplicationWithReference(NOS_FOURCC, nosPid))
         nosEngine.LogD("Device %s released by Nodos", GetDisplayName().c_str());
     else
         nosEngine.LogE("Failed to release device %s", GetDisplayName().c_str());


### PR DESCRIPTION
This was probably caused by aja driver resetting the device state after an application releases the device. Fixed by acquiring/releasing with refcounting provided by aja sdk itself.