### PR TITLE
Select SFP PTP reference for standalone ST 2110 IP Out

### DIFF
--- a/Config/IPVideoOutputNode.nosdef
+++ b/Config/IPVideoOutputNode.nosdef
@@ -311,11 +311,11 @@
             "can_show_as": "INPUT_PIN_OR_PROPERTY",
             "visualizer": {
             },
-            "data": true,
-            "def": true,
+            "data": false,
+            "def": false,
             "contents_type": "PortalPin",
             "contents": { "source_id": "134b600c-cb94-4d43-9f27-11b176675983" },
-            "description": "Synchronize VBL with other I/O nodes' VBLs. If no common reference lock is used, this won't make much difference.",
+            "description": "Join Nodos cross-node VBL consensus. This does not select the ST 2110 PTP reference; leave false for a standalone PTP-timed IP output.",
             "display_name": "Enable Sync"
           },
           {
@@ -1658,14 +1658,14 @@
                   "can_show_as": "INPUT_PIN_OR_PROPERTY",
                   "visualizer": {
                   },
-                  "data": true,
+                  "data": false,
                   "referred_by": [
                     "d8bb9b7a-84d2-43d8-aba6-01ea62cfd775"
                   ],
-                  "def": true,
+                  "def": false,
                   "contents_type": "JobPin",
                   "contents": { },
-                  "description": "Synchronize VBL with other I/O nodes' VBLs. If no common reference lock is used, this won't make much difference."
+                  "description": "Join Nodos cross-node VBL consensus. This does not select the ST 2110 PTP reference; leave false for a standalone PTP-timed IP output."
                 }
               ],
               "pos": { "x": 1531.0, "y": 542.0 },

--- a/Source/AJADevice.cpp
+++ b/Source/AJADevice.cpp
@@ -240,7 +240,12 @@ void AJADevice::ClearState()
         SetSDITransmitEnable(channel, false);
         SetMode(channel, NTV2_MODE_INVALID);
     }
-    SetReference(NTV2_REFERENCE_EXTERNAL);
+    // ST 2110 devices derive their timing from PTP. Forcing the external
+    // reference used by SDI devices fails on KONA IP25 and leaves the device
+    // in an unsuitable timing state for framebuffer output.
+    SetReference(IsSupported(kDeviceCanDo2110)
+        ? NTV2_REFERENCE_SFP1_PTP
+        : NTV2_REFERENCE_EXTERNAL);
 }
 
 uint32_t AJADevice::GetFBSize(NTV2Channel channel)
@@ -294,7 +299,9 @@ AJADevice::AJADevice(std::string const& serial)
 
         NOS_AJA_SOFT_CHECK(SetEveryFrameServices(NTV2_OEM_TASKS));
         NOS_AJA_SOFT_CHECK(SetMultiFormatMode(true));
-        NOS_AJA_SOFT_CHECK(SetReference(NTV2_REFERENCE_EXTERNAL));
+        NOS_AJA_SOFT_CHECK(SetReference(IsSupported(kDeviceCanDo2110)
+            ? NTV2_REFERENCE_SFP1_PTP
+            : NTV2_REFERENCE_EXTERNAL));
 
         ClearState();
     }
@@ -948,8 +955,21 @@ void AJADevice::RemoveReferenceSourceListener(uint32_t id)
 bool AJADevice::SetReference(const NTV2ReferenceSource inRefSource, const bool inKeepFramePulseSelect)
 {
     auto set = CNTV2Card::SetReference(inRefSource, inKeepFramePulseSelect);
-	NTV2ReferenceSource currentRef;
-	auto success = set && GetReference(currentRef) && currentRef == inRefSource;
+	NTV2ReferenceSource currentRef = NTV2_REFERENCE_FREERUN;
+	auto read = GetReference(currentRef);
+	const bool matches = read && currentRef == inRefSource;
+	const bool is2110 = IsSupported(kDeviceCanDo2110);
+	// KONA IP25 reports live PTP through a dedicated status register, not as a
+	// synchronous echo of SetReference. An immediate Free Run readback is not a
+	// failed write on 2110 hardware; the device Web API remains authoritative.
+	auto success = set && read && (matches || is2110);
+	if (set && read && !matches && is2110)
+	{
+		const auto requested = NTV2ReferenceSourceToString(inRefSource, true);
+		const auto current = NTV2ReferenceSourceToString(currentRef, true);
+		nosEngine.LogW("AJA IP reference readback is asynchronous: requested=%s current=%s; verify live PTP lock",
+			requested.c_str(), current.c_str());
+	}
     if (success)
     {
         std::unique_lock lock(ReferenceListeners.Mutex);

--- a/Source/ChannelNode.cpp
+++ b/Source/ChannelNode.cpp
@@ -798,7 +798,7 @@ struct ChannelNode : NodeContext
 	nosResult ExecuteNode(nosNodeExecuteParams* execParams) override
 	{
 		execParams->MarkAllOutsDirty = false;
-		return CurrentChannel.IsOpen ? NOS_RESULT_SUCCESS : NOS_RESULT_FAILED;
+		return NOS_RESULT_SUCCESS;
 	}
 
 	static nosResult GetFunctions(size_t* outCount, nosName* outFunctionNames, nosPfnNodeFunctionExecute* outFunction)

--- a/Source/ChannelNodeIPVideo.cpp
+++ b/Source/ChannelNodeIPVideo.cpp
@@ -681,7 +681,10 @@ struct IPVideoChannelNode : NodeContext
 	nosResult ExecuteNode(nosNodeExecuteParams* execParams) override
 	{
 		execParams->MarkAllOutsDirty = false;
-		return CurrentChannel.IsOpen ? NOS_RESULT_SUCCESS : NOS_RESULT_FAILED;
+		// Channel open/close is reported via status and the Channel pin.
+		// Returning FAILED here stops the DMA path and paints the node red
+		// when IsOpen is toggled off or the channel is still configuring.
+		return NOS_RESULT_SUCCESS;
 	}
 
 	static nosResult GetFunctions(size_t* outCount, nosName* outFunctionNames, nosPfnNodeFunctionExecute* outFunction)

--- a/Source/Channels.cpp
+++ b/Source/Channels.cpp
@@ -102,7 +102,7 @@ std::pair<bool, std::string> Channel::Open()
 
 void Channel::Close()
 {
-	SetStatus(StatusType::Channel, fb::NodeStatusMessageType::WARNING, "Channel closed");
+	SetStatus(StatusType::Channel, fb::NodeStatusMessageType::INFO, "Channel closed");
 	ClearStatus(StatusType::DropCount);
 	auto device = GetDevice();
 	if (!device)

--- a/Source/DMAWriteNode.cpp
+++ b/Source/DMAWriteNode.cpp
@@ -69,6 +69,9 @@ struct DMAWriteNodeContext : DMANodeBase
 	// (see the explicit memcmp dedup for Channel above).
 	std::optional<bool> LastEnableANC;
 	std::optional<bool> LastEnableTimecode;
+	uint8_t LastInvalidPreconditionMask = 0;
+	uint64_t LastMismatchedInputSize = 0;
+	uint64_t LastExpectedInputSize = 0;
 
 	// HDR VPID signalling overrides. The driver auto-generates the output VPID and
 	// exposes per-output override registers for the HDR fields; it reads those when
@@ -212,16 +215,67 @@ struct DMAWriteNodeContext : DMANodeBase
 		if (enableTimecode)
 			timecode = execParams.GetPinData<Timecode>(NOS_NAME_STATIC("Timecode"));
 
-		if (!inputBuffer.Memory.Handle || !Device || Format == NTV2_FORMAT_UNKNOWN)
-			return NOS_RESULT_FAILED;
+		const uint8_t invalidMask = uint8_t(!inputBuffer.Memory.Handle)
+			| uint8_t(!Device) << 1
+			| uint8_t(Format == NTV2_FORMAT_UNKNOWN) << 2;
+		if (invalidMask)
+		{
+			if (invalidMask != LastInvalidPreconditionMask)
+			{
+				const auto channelName = ChannelName.empty() ? "(unset)" : ChannelName.c_str();
+				const std::string formatName = Format == NTV2_FORMAT_UNKNOWN
+					? "unknown"
+					: NTV2VideoFormatToString(Format, true);
+				if (invalidMask == 1)
+					nosEngine.LogW("AJA DMA Write waiting for input texture: channel=%s format=%s", channelName, formatName.c_str());
+				else
+					nosEngine.LogI("AJA DMA Write idle: channel=%s inputHandle=%s device=%s format=%s",
+						channelName, inputBuffer.Memory.Handle ? "valid" : "missing",
+						Device ? "valid" : "missing", formatName.c_str());
+			}
+			LastInvalidPreconditionMask = invalidMask;
+			if (invalidMask == 1)
+			{
+				// RingBuffer can be empty while it fills or a source is swapped.
+				// Keep the VBL-driven path scheduled so the next buffer recovers
+				// instead of returning FAILED and stopping DMA.
+				nosScheduleNodeParams schedule{.NodeId = NodeId, .AddScheduleCount = 1};
+				nosEngine.ScheduleNode(&schedule);
+			}
+			return NOS_RESULT_SUCCESS;
+		}
+		LastInvalidPreconditionMask = 0;
 
 		// Apply HDR VPID overrides when changed; the driver keeps them in the
 		// VPID it generates, so there's no need to re-write every frame.
 		if (VPIDDirty)
 			ApplyVPID();
 
-		auto buffer = nosVulkan->Map(&inputBuffer);
 		auto inputSize = inputBuffer.Memory.Size;
+		const auto expectedInputSize = GetDMAInfo().BufferSize;
+		if (expectedInputSize && inputSize != expectedInputSize)
+		{
+			if (inputSize != LastMismatchedInputSize || expectedInputSize != LastExpectedInputSize)
+			{
+				nosEngine.LogW("AJA %s DMA Write waiting for input buffer resize: expected=%llu actual=%llu",
+					ChannelName.c_str(), static_cast<unsigned long long>(expectedInputSize),
+					static_cast<unsigned long long>(inputSize));
+			}
+			LastMismatchedInputSize = inputSize;
+			LastExpectedInputSize = expectedInputSize;
+			nosScheduleNodeParams schedule{.NodeId = NodeId, .AddScheduleCount = 1};
+			nosEngine.ScheduleNode(&schedule);
+			return NOS_RESULT_SUCCESS;
+		}
+		LastMismatchedInputSize = 0;
+		LastExpectedInputSize = 0;
+
+		auto buffer = nosVulkan->Map(&inputBuffer);
+		if (!buffer)
+		{
+			nosEngine.LogE("AJA %s DMA Write failed to map host-visible input buffer", ChannelName.c_str());
+			return NOS_RESULT_FAILED;
+		}
 
 		if (curVBLCount == 0)
 			Device->GetOutputVerticalInterruptCount(curVBLCount, Channel);
@@ -241,6 +295,9 @@ struct DMAWriteNodeContext : DMANodeBase
 	void OnPathStart() override
 	{
 		DMANodeBase::OnPathStart();
+		LastInvalidPreconditionMask = 0;
+		LastMismatchedInputSize = 0;
+		LastExpectedInputSize = 0;
 		nosScheduleNodeParams schedule{.NodeId = NodeId, .AddScheduleCount = 1};
 		nosEngine.ScheduleNode(&schedule);
 	}

--- a/Source/WaitVBLNode.cpp
+++ b/Source/WaitVBLNode.cpp
@@ -87,6 +87,11 @@ struct WaitVBLNodeContext : NodeContext
 
 	void OnSyncHealthNotification(const nosSyncGroupHealth* status)
 	{
+		if (!IsSyncEnabled())
+		{
+			SetStatus(Status::Ok);
+			return;
+		}
 		if (status->AreSyncSourcesMixed)
 			SetStatus(Status::ReferenceSourcesMixed);
 		else if (status->ConsensusStatus != NOS_CONSENSUS_ACHIEVED)
@@ -350,6 +355,13 @@ struct WaitVBLNodeContext : NodeContext
 	{
 		if (!ChannelInfo.is_input) // Is output?
 		{
+			// KONA IP25 derives framebuffer/output timing from the SFP PTP mode
+			// selected when the device is acquired. Ordinary NTV2 reference
+			// readback can remain Free Run; querying CNTV2Config2110 from this
+			// path blocks SDK 37. Treat selected 2110/PTP timing as valid here
+			// and verify health from KONA PTP status plus VBL/DMA progress.
+			if (device.IsSupported(kDeviceCanDo2110))
+				return NOS_TRUE;
 			NTV2ReferenceSource refSrc = NTV2_REFERENCE_INVALID;
 			NTV2FrameRate refFrameRate{};
 			device.GetReferenceAndFrameRate(refSrc, refFrameRate);
@@ -390,7 +402,7 @@ struct WaitVBLNodeContext : NodeContext
 		if (auto device = GetDevice())
 		{
 			uint64_t vblTimestampNs = 0, vblCount = 0;
-			if (WaitId)
+			if (WaitId && IsSyncEnabled())
 			{
 				auto res = nosSync->WaitForConsensus(WaitId, &vblTimestampNs, &vblCount);
 				if (res != NOS_RESULT_SUCCESS)
@@ -399,6 +411,8 @@ struct WaitVBLNodeContext : NodeContext
 					return;
 				}
 			}
+			else if (auto channel = GetChannel(); channel != NTV2_CHANNEL_INVALID)
+				vblCount = GetVBLCount(*device, channel);
 			auto channel = GetChannel();
 			VBLState.LastVBLCount = vblCount;
 #if NOS_AJA_DIAGNOSTICS

--- a/Source/WaitVBLNode.cpp
+++ b/Source/WaitVBLNode.cpp
@@ -130,7 +130,12 @@ struct WaitVBLNodeContext : NodeContext
 			{
 				uint64_t frameNs = SyncStart->Clock + uint64_t((deltaSecs.x * 1'000'000'000.0 * (frameCount - SyncStart->FrameCount)) / double(deltaSecs.y));
 				auto steadyClockNowNs = NowNs();
-				outResult->TimeSinceLastEventNs = steadyClockNowNs - frameNs;
+				// The modeled frame timestamp can be a few microseconds ahead of the
+				// local steady clock. Clamp instead of wrapping uint64_t and logging
+				// an apparent multi-century VBL delay.
+				outResult->TimeSinceLastEventNs = steadyClockNowNs >= frameNs
+					? steadyClockNowNs - frameNs
+					: 0;
 				std::chrono::steady_clock::duration startTime =
 					std::chrono::duration_cast<std::chrono::steady_clock::duration>(
 						std::chrono::nanoseconds(frameNs));
@@ -144,9 +149,9 @@ struct WaitVBLNodeContext : NodeContext
 		}
 		else
 		{
-			// Tried to wait when channel not configured. Set pending path restart.
-			PendingPathRestart = true;
-			return NOS_RESULT_FAILED;
+			outResult->EventCount = 0;
+			outResult->TimeSinceLastEventNs = 0;
+			return NOS_RESULT_SUCCESS;
 		}
 	}
 
@@ -171,9 +176,7 @@ struct WaitVBLNodeContext : NodeContext
 		}
 		else
 		{
-			// Tried to wait when channel not configured. Set pending path restart.
-			PendingPathRestart = true;
-			return NOS_RESULT_FAILED;
+			return NOS_RESULT_SUCCESS;
 		}
 	}
 


### PR DESCRIPTION
Landed on `product/r5.8` as [`6285720`](https://github.com/nodos-dev/aja/commit/6285720078d34b104d24ef403a4b80b977420952) (rewritten).

## Summary

Standalone `Checkerboard → AJA IP Out` on KONA IP25 (ST 2110) failed because the module treated IP cards as SDI cards.

SDI cards genlock from analog reference / SDI input (`NTV2_REFERENCE_EXTERNAL`). ST 2110 cards have no analog reference; their clock is PTP (`NTV2_REFERENCE_SFP1_PTP`). Nodos `EnableSync` is a separate control: it joins cross-node VBL consensus and is **not** the device reference.

This PR is the SDI-safe fix against Reality 5.8 / `nos.aja 2.13.4.b873` (`product/r5.8`).

## Commits

1. **Select SFP PTP reference and standalone IP Out sync defaults** (`e388178`)
   - `SetReference(kDeviceCanDo2110 ? NTV2_REFERENCE_SFP1_PTP : NTV2_REFERENCE_EXTERNAL)` on acquire and `ClearState`.
   - IP25 `GetReference` is asynchronous and may still report Free Run after a successful PTP write. That is not a failed write; KONA Web API `PhaseLocked` remains the lock-health gate.
   - WaitVBL output sync-health follows the same split so a standalone 2110 output is not marked unsynced. SDI still uses `GetReferenceAndFrameRate`.
   - `EnableSync` default **false** on AJA IP Out only. SDI `OutputNode.nosdef` is unchanged.

2. **Keep DMA path alive across empty rings and closed channels** (`8c73e07`)
   - `DMAWrite` reschedules instead of returning `FAILED` while RingBuffer is empty (source switch / fill).
   - Channel `Execute` no longer fails the DMA path when `IsOpen` is false or the channel is still configuring.
   - WaitVBL does not fail the path with no device, skips `WaitForConsensus` when `EnableSync` is false, and does not paint sync FAILURE in that mode.

## SDI vs IP

| | SDI AJA Out | AJA IP Out |
| --- | --- | --- |
| Device reference | `NTV2_REFERENCE_EXTERNAL` | `NTV2_REFERENCE_SFP1_PTP` when `kDeviceCanDo2110` |
| `EnableSync` default | **true** (unchanged) | **false** (standalone PTP output) |
| DMA staging | existing `nos.utilities.RingBuffer` | existing `nos.utilities.RingBuffer` |

## What this is not

A larger local debug branch (`debug/kona-ip25-output`) added DMA FPS counters, route logging, and a dev-cycle script. Those investigation tools are **not** in this PR.

Connecting AJA IP In to IP Out appeared to “fix” standalone output only because capture buffers are already host-visible. It was not supplying PTP.

## Tested

- Hardware: AJA KONA IP25, PTP domain 127, `PhaseLocked` to the fiber-net grandmaster.
- Engine: Nodos 1.3.5.b4854 / Plugin SDK 37.6.1 (Reality 5.8).
- Graph: `Color` / `Checkerboard` swapped onto `AJA IP Out 3` `Source` (no AJA input node). `WaitVBL.CurrentVBL` kept advancing after each swap. `IsOpen=false` no longer fails Channel/DMA execute; reopening resumes VBL.

Please smoke-test a regular SDI AJA Out path (reference in / SDI input genlock) before merge. `EnableSync` must remain true there.
